### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ If you run into any problems with the installation instructions please contact @
 
 ## Install with Nix
 
+Add dapptools build caches:
+
+```sh
+nix run nixpkgs.cachix -c cachix use dapp
+```
+
 Get the Scuttlbot private network keys (caps) from an admin and put it in a file
 (e.g. called `secret-ssb-caps.json`). The file should have the JSON format:
 `{ "shs": "<BASE64>", "sign": "<BASE64>" }`.

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 , nodepkgs ? import ./nix/nodepkgs.nix { inherit pkgs; }
 
 , setzer-mcdSrc ? fetchGit {
-    url = "git@github.com:makerdao/setzer-mcd";
+    url = "https://github.com/makerdao/setzer-mcd";
     ref = "master";
     rev = "c528da640393a3d79ef314a7f86ae363d503a240";
   }

--- a/omnia/config/feed.conf
+++ b/omnia/config/feed.conf
@@ -21,6 +21,6 @@
 		"ETHUSD": {
 			"msgExpiration": 1800,
 			"msgSpread": 0.5
-		},
+		}
 	}
 }

--- a/omnia/config/relayer.conf
+++ b/omnia/config/relayer.conf
@@ -30,6 +30,6 @@
 			"oracleSpread": 1,
 			"oracleExpiration": 3600,
 			"msgExpiration": 1800
-		},
+		}
 	}
 }


### PR DESCRIPTION
- use `https` URL for `setzer-mcd` now that it's a public repo
- fix malformed JSON in configs
- add dapptools nix cache setup instructions to readme