### PR TITLE
Add --network option to installer

### DIFF
--- a/smoke-tests/test.sh
+++ b/smoke-tests/test.sh
@@ -24,6 +24,7 @@ install_relayer() {
   sleep 2
 
   install-omnia relayer \
+    --network      "testnet" \
     --ssb-external "example-2.org" \
     | sudo sh
 }
@@ -35,7 +36,7 @@ after() {
 
 . "$tpath/tap.sh"
 
-plan 30
+plan 31
 timeout 60
 
 note <<<"INSTALL FEED"
@@ -112,6 +113,8 @@ assert "Ethereum keystore not overwritten" \
   json .ethereum.keystore <<<"\"$keystore_path\""
 assert "Keystore password file not overwritten" \
   json .ethereum.password <<<"\"$key_path\""
+assert "Has set ethereum network" \
+  json .ethereum.network <<<'"testnet"'
 
 sleep 2
 

--- a/systemd/install-omnia
+++ b/systemd/install-omnia
@@ -21,7 +21,7 @@ Options:
   --keystore     PATH             Set Ethereum keystore path
   --password     PATH             Set Ethereum keystore password file path
   --network      ETH_NETWORK      Set relayer Ethereum network
-  --ssb-caps     CAPS_FILE        Set Scuttlbot caps from file
+  --ssb-caps     CAPS_FILE        Set Scuttlebot caps from file
   --ssb-external EXTERNAL_ADDRS   Set Scuttlbot external IP/host address
   --ssb-secret   SECRET_FILE      Install Scuttlbot secret
   --ssb-gossip   GOSSIP_JSON_FILE Install Scuttlbot gossip.json file

--- a/systemd/install-omnia
+++ b/systemd/install-omnia
@@ -17,9 +17,10 @@ Commands:
   help          Print this message
 
 Options:
-  --from ADDRESS                  Set Ethereum address to use for signing
-  --keystore PATH                 Set Ethereum keystore path
-  --password PATH                 Set Ethereum keystore password file path
+  --from         ADDRESS          Set Ethereum address to use for signing
+  --keystore     PATH             Set Ethereum keystore path
+  --password     PATH             Set Ethereum keystore password file path
+  --network      ETH_NETWORK      Set relayer Ethereum network
   --ssb-caps     CAPS_FILE        Set Scuttlbot caps from file
   --ssb-external EXTERNAL_ADDRS   Set Scuttlbot external IP/host address
   --ssb-secret   SECRET_FILE      Install Scuttlbot secret
@@ -145,6 +146,9 @@ while [[ -n "$1" ]]; do
       ;;
     --password)
       configUpdates+=( ".ethereum.password = \"$2\"" );shift
+      ;;
+    --network)
+      configUpdates+=( ".ethereum.network = \"$2\"" );shift
       ;;
     --ssb-external)
       ssbConfigUpdates+=( ".connections.incoming[\"net\",\"ws\"][].external = \"$2\"" );shift

--- a/systemd/install-omnia
+++ b/systemd/install-omnia
@@ -22,7 +22,7 @@ Options:
   --password     PATH             Set Ethereum keystore password file path
   --network      ETH_NETWORK      Set relayer Ethereum network
   --ssb-caps     CAPS_FILE        Set Scuttlebot caps from file
-  --ssb-external EXTERNAL_ADDRS   Set Scuttlbot external IP/host address
+  --ssb-external EXTERNAL_ADDRS   Set Scuttlebot external IP/host address
   --ssb-secret   SECRET_FILE      Install Scuttlbot secret
   --ssb-gossip   GOSSIP_JSON_FILE Install Scuttlbot gossip.json file
 EOF

--- a/systemd/install-omnia
+++ b/systemd/install-omnia
@@ -23,7 +23,7 @@ Options:
   --network      ETH_NETWORK      Set relayer Ethereum network
   --ssb-caps     CAPS_FILE        Set Scuttlebot caps from file
   --ssb-external EXTERNAL_ADDRS   Set Scuttlebot external IP/host address
-  --ssb-secret   SECRET_FILE      Install Scuttlbot secret
+  --ssb-secret   SECRET_FILE      Install Scuttlebot secret
   --ssb-gossip   GOSSIP_JSON_FILE Install Scuttlbot gossip.json file
 EOF
   exit 1


### PR DESCRIPTION
## Merge Criteria

- [x] install `omnia` as a *feed* on a clean VPS using `install-omnia`
  - [x] make sure `systemctl status omnia` is `active` and hasn't exited
  - [x] check that output from `journalctl -e -u omnia` looks reasonable
  - [x] make sure `systemctl status ssb-server` is `active` and hasn't exited
  - [x] check that output from `journalctl -e -u ssb-server` looks reasonable
  - [x] reboot VPS and make sure services auto-start
- [x] install `omnia` as a *relayer* on a clean VPS using `install-omnia`
  - [x] make sure `systemctl status omnia` is `active` and hasn't exited
  - [x] check that output from `journalctl -e -u omnia` looks reasonable
  - [x] make sure `systemctl status ssb-server` is `active` and hasn't exited
  - [x] check that output from `journalctl -e -u ssb-server` looks reasonable
  - [x] reboot VPS and make sure services auto-start
